### PR TITLE
Fix Obfuscated Value Off by More Than 10

### DIFF
--- a/mii-process-feasibility/src/main/java/de/medizininformatik_initiative/process/feasibility/FeasibilityCachingLaplaceCountObfuscator.java
+++ b/mii-process-feasibility/src/main/java/de/medizininformatik_initiative/process/feasibility/FeasibilityCachingLaplaceCountObfuscator.java
@@ -61,7 +61,7 @@ public class FeasibilityCachingLaplaceCountObfuscator implements Obfuscator<Inte
         var divDist = sensitivity / epsilon;
         var min = -0.5;
         var max = 0.5;
-        var random = rand.nextDouble();
+        var random = rand.nextDouble(0.1d, 0.9d);
         var uniform = min + random * (max - min);
         return meanDist - divDist * Math.signum(uniform) * Math.log(1 - 2 * Math.abs(uniform));
     }

--- a/mii-process-feasibility/src/main/java/de/medizininformatik_initiative/process/feasibility/spring/config/EvaluationConfig.java
+++ b/mii-process-feasibility/src/main/java/de/medizininformatik_initiative/process/feasibility/spring/config/EvaluationConfig.java
@@ -21,7 +21,7 @@ public class EvaluationConfig {
     @Value("${de.medizininformatik_initiative.feasibility_dsf_process.evaluation.obfuscation.sensitivity:1.0}")
     private double obfuscationLaplaceSensitivity;
 
-    @Value("${de.medizininformatik_initiative.feasibility_dsf_process.evaluation.obfuscation.epsilon:0.5}")
+    @Value("${de.medizininformatik_initiative.feasibility_dsf_process.evaluation.obfuscation.epsilon:0.28}")
     private double obfuscationLaplaceEpsilon;
 
     @Value("${de.medizininformatik_initiative.feasibility_dsf_process.rate.limit.count:999}")

--- a/mii-process-feasibility/src/test/java/de/medizininformatik_initiative/process/feasibility/FeasibilityCachingLaplaceCountObfuscatorTest.java
+++ b/mii-process-feasibility/src/test/java/de/medizininformatik_initiative/process/feasibility/FeasibilityCachingLaplaceCountObfuscatorTest.java
@@ -1,12 +1,13 @@
 package de.medizininformatik_initiative.process.feasibility;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.RepeatedTest;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.security.SecureRandom;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -18,25 +19,32 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class FeasibilityCachingLaplaceCountObfuscatorTest {
 
     private static final int RESULT = 490715;
+    private static SecureRandom rand;
+
     private FeasibilityCachingLaplaceCountObfuscator obfuscator;
 
     private static Stream<Integer> resultRange() {
         return IntStream.rangeClosed(-100, 1000).boxed();
     }
 
-    @BeforeEach
-    public void setUp() {
-        obfuscator = new FeasibilityCachingLaplaceCountObfuscator(1, 0.5);
+    @BeforeAll
+    public static void init() {
+        rand = new SecureRandom();
     }
 
-    @Test
+    @BeforeEach
+    public void setUp() {
+        obfuscator = new FeasibilityCachingLaplaceCountObfuscator(1, 0.28);
+    }
+
+    @RepeatedTest(100)
     @DisplayName("obfuscated result is rounded to nearest tens")
     public void checkIfObfuscatedResultIsNearestTens() {
-        var result = 490715;
+        var result = rand.nextInt(0, Integer.MAX_VALUE);
         var obfuscatedResult = obfuscator.obfuscate(result);
 
         assertTrue(obfuscatedResult % 10 == 0, "obfuscated result is not rounded to tens");
-        assertTrue(Math.abs(result - obfuscatedResult) < 10, "obfuscated result is not rounded to nearest tens");
+        assertTrue(Math.abs(result - obfuscatedResult) <= 10, "obfuscated result is not rounded to nearest tens");
     }
 
     @RepeatedTest(100)


### PR DESCRIPTION
The library is [samply/laplace-java](https://github.com/samply/laplace-java) has no maven artifact published, hence cannot be used at this time.

Using the recommended default of 0.28 for epsilon.

There is an about 5% chance that the obfuscated value can be off by up to 20. Shrinking the interval a random number is chosen from for the laplace distribution from [0.0d, 10.d) to [0.1d, 0.9d) reduces the chance to 0%.

Closes #131