### PR TITLE
Revert "Update hapi.fhir.version to v7 (major)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <compileSource>17</compileSource>
         <compileTarget>17</compileTarget>
         <dsf.version>1.6.0</dsf.version>
-        <hapi.fhir.version>7.6.1</hapi.fhir.version>
+        <hapi.fhir.version>5.7.9</hapi.fhir.version>
         <testcontainers.version>1.20.4</testcontainers.version>
     </properties>
 


### PR DESCRIPTION
Reverts medizininformatik-initiative/mii-process-feasibility#189

Incompatible with BPE v1.6.0