### PR TITLE
Revert "Update hapi.fhir.version to v5.7.9"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <compileSource>17</compileSource>
         <compileTarget>17</compileTarget>
         <dsf.version>1.6.0</dsf.version>
-        <hapi.fhir.version>5.7.9</hapi.fhir.version>
+        <hapi.fhir.version>5.1.0</hapi.fhir.version>
         <testcontainers.version>1.20.4</testcontainers.version>
     </properties>
 


### PR DESCRIPTION
This reverts #174

Incompatible with BPE v1.6.0