### PR TITLE
Log Library Contents and MeasureReport Population Count for Debugging

### DIFF
--- a/mii-process-feasibility/README.md
+++ b/mii-process-feasibility/README.md
@@ -150,6 +150,35 @@ This version of the process is compatible with the following components:
 
 **Note:** Flare got rewritten. Only the [new project][9] is supported.
 
+## Monitoring Requests and Responses
+
+The debug logs, located in the bpe logs folder, contain information about the feasibility tasks executed at your site.
+These include the url's of the Measure and MeasureReport resources along the execution time for evaluating a query
+against the data FHIR store and the result count of the MeasureReport sent back to the feasibility task requester.
+
+### Structured Query
+
+For Structured Queries, you can enable the debug logs of your Flare instance to log the evaluated query.
+
+### CQL Query
+
+For CQL queries, the bpe debug logs contain the URL to the Measure resource in your data FHIR store that is evaluated.
+You can retrieve the Measure resource by opening the URL with an HTTP client and using the configured authentication
+method, if any, of your data FHIR store. The Measure resource contains a reference to the Library resource, which may
+have to be prefixed with the data FHIR store base url and then can be opened the same way. The Library resource contains
+the base64 encoded CQL query, which can be decoded using, for example, the command line tool base64.
+
+The following code snippet shows how to retrieve the CQL query using Linux command line tools and basic authentication
+for accessing the data FHIR store:
+
+```sh
+MEASURE_URL="https://fhir-store.foo/fhir/Measure/AABBCCDDEE" # retrieved from debug log
+BASE_URL="$(echo "$MEASURE_URL" | sed -E 's#Measure/.*$##')"
+LIBRARY_REF="$(curl -sL -H "Accept: application/fhir+json" -u "login:password" "$MEASURE_URL" | jq -r '.library[0]')"
+LIBRARY_URL="$BASE_URL$(echo "$LIBRARY_REF" | sed -E 's#^.*(Library/.*)$#\1#')"
+curl -sL -H "Accept: application/fhir+json" -u "login:password" "$LIBRARY_URL" | jq -r '.content[0].data' | base64 --decode
+```
+
 
 [1]: <https://www.hl7.org/FHIR/task.html>
 [2]: <https://www.hl7.org/fhir/measure.html>

--- a/mii-process-feasibility/src/main/java/de/medizininformatik_initiative/process/feasibility/client/flare/FlareWebserviceClientImpl.java
+++ b/mii-process-feasibility/src/main/java/de/medizininformatik_initiative/process/feasibility/client/flare/FlareWebserviceClientImpl.java
@@ -59,7 +59,9 @@ public class FlareWebserviceClientImpl implements FlareWebserviceClient {
             return httpClient.execute(req, new BasicResponseHandler());
         } catch (IOException e) {
             throw new IOException(
-                    format("Error sending %s request to flare webservice url '%s'.", req.getMethod(), req.getURI()), e);
+                    format("Error sending %s request to flare webservice url '%s': %s", req.getMethod(), req.getURI(),
+                            e.getMessage()),
+                    e);
         }
     }
 }

--- a/mii-process-feasibility/src/main/java/de/medizininformatik_initiative/process/feasibility/service/DownloadFeasibilityResources.java
+++ b/mii-process-feasibility/src/main/java/de/medizininformatik_initiative/process/feasibility/service/DownloadFeasibilityResources.java
@@ -48,7 +48,7 @@ public class DownloadFeasibilityResources extends AbstractServiceDelegate
 
         var measureId = getMeasureId(task);
         var client = clientProvider.getWebserviceClientByReference(measureId);
-        var bundle = getMeasureAndLibrary(measureId, client);
+        var bundle = getMeasureAndLibrary(measureId, client, task);
 
         variables.setResource(ConstantsFeasibility.VARIABLE_MEASURE, bundle.getEntry().get(0).getResource());
         variables.setResource(ConstantsFeasibility.VARIABLE_LIBRARY, bundle.getEntry().get(1).getResource());
@@ -61,12 +61,13 @@ public class DownloadFeasibilityResources extends AbstractServiceDelegate
         if (measureRef.isPresent()) {
             return new IdType(measureRef.get().getReference());
         } else {
-            logger.error("Task {} is missing the measure reference.", task.getId());
+            logger.error("Task is missing the measure reference [task: {}]",
+                    api.getTaskHelper().getLocalVersionlessAbsoluteUrl(task));
             throw new RuntimeException("Missing measure reference.");
         }
     }
 
-    private Bundle getMeasureAndLibrary(IdType measureId, FhirWebserviceClient client) {
+    private Bundle getMeasureAndLibrary(IdType measureId, FhirWebserviceClient client, Task task) {
         try {
             var bundle = client.searchWithStrictHandling(Measure.class,
                     Map.of("_id", Collections.singletonList(measureId.getIdPart()), "_include",
@@ -84,8 +85,9 @@ public class DownloadFeasibilityResources extends AbstractServiceDelegate
 
             return bundle;
         } catch (Exception e) {
-            logger.warn("Error while reading Measure with id {} including its Library from {}: {}",
-                    measureId.getIdPart(), client.getBaseUrl(), e.getMessage());
+            logger.warn("Error while reading Measure with id {} including its Library from {}: {} [task: {}]",
+                    measureId.getIdPart(), client.getBaseUrl(), e.getMessage(),
+                    api.getTaskHelper().getLocalVersionlessAbsoluteUrl(task));
             throw e;
         }
     }

--- a/mii-process-feasibility/src/main/java/de/medizininformatik_initiative/process/feasibility/service/DownloadMeasureReport.java
+++ b/mii-process-feasibility/src/main/java/de/medizininformatik_initiative/process/feasibility/service/DownloadMeasureReport.java
@@ -43,12 +43,13 @@ public class DownloadMeasureReport extends AbstractServiceDelegate implements In
         var measureReportId = getMeasureReportId(task);
         var client = clientProvider
                 .getWebserviceClientByReference(measureReportId);
-        var measureReport = downloadMeasureReport(client, measureReportId);
+        var measureReport = downloadMeasureReport(client, measureReportId, task);
         execution.setVariableLocal(VARIABLE_MEASURE_REPORT, measureReport);
     }
 
-    private MeasureReport downloadMeasureReport(FhirWebserviceClient client, IdType measureReportId) {
-        logger.debug("Download MeasureReport with ID {} from {}", measureReportId.getIdPart(), client.getBaseUrl());
+    private MeasureReport downloadMeasureReport(FhirWebserviceClient client, IdType measureReportId, Task task) {
+        logger.debug("Download MeasureReport with ID {} from {} [task: {}]", measureReportId.getIdPart(),
+                client.getBaseUrl(), api.getTaskHelper().getLocalVersionlessAbsoluteUrl(task));
         return client.read(MeasureReport.class, measureReportId.getIdPart());
     }
 
@@ -59,7 +60,8 @@ public class DownloadMeasureReport extends AbstractServiceDelegate implements In
         if (measureRef.isPresent()) {
             return new IdType(measureRef.get().getReference());
         } else {
-            logger.error("Task {} is missing the measure report reference.", task.getId());
+            logger.error("Task is missing the measure report reference [task: {}]",
+                    api.getTaskHelper().getLocalVersionlessAbsoluteUrl(task));
             throw new RuntimeException("Missing measure report reference.");
         }
     }

--- a/mii-process-feasibility/src/main/java/de/medizininformatik_initiative/process/feasibility/service/EvaluateCqlMeasure.java
+++ b/mii-process-feasibility/src/main/java/de/medizininformatik_initiative/process/feasibility/service/EvaluateCqlMeasure.java
@@ -7,10 +7,12 @@ import dev.dsf.bpe.v1.variables.Variables;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.DateType;
+import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.MeasureReport;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.Parameters.ParametersParameterComponent;
+import org.hl7.fhir.r4.model.Quantity;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.StringType;
 import org.slf4j.Logger;
@@ -23,6 +25,8 @@ import java.util.Optional;
 
 import static de.medizininformatik_initiative.process.feasibility.variables.ConstantsFeasibility.HEADER_PREFER;
 import static de.medizininformatik_initiative.process.feasibility.variables.ConstantsFeasibility.HEADER_PREFER_RESPOND_ASYNC;
+import static de.medizininformatik_initiative.process.feasibility.variables.ConstantsFeasibility.INITIAL_POPULATION;
+import static de.medizininformatik_initiative.process.feasibility.variables.ConstantsFeasibility.MEASURE_POPULATION;
 import static de.medizininformatik_initiative.process.feasibility.variables.ConstantsFeasibility.MEASURE_REPORT_PERIOD_END;
 import static de.medizininformatik_initiative.process.feasibility.variables.ConstantsFeasibility.MEASURE_REPORT_PERIOD_START;
 import static de.medizininformatik_initiative.process.feasibility.variables.ConstantsFeasibility.MEASURE_REPORT_TYPE_POPULATION;
@@ -31,12 +35,12 @@ import static de.medizininformatik_initiative.process.feasibility.variables.Cons
 
 public class EvaluateCqlMeasure extends AbstractServiceDelegate implements InitializingBean {
 
+    private static final String BLAZE_EVAL_DURATION_URL = "https://samply.github.io/blaze/fhir/StructureDefinition/eval-duration";
     private static final Logger logger = LoggerFactory.getLogger(EvaluateCqlMeasure.class);
 
-    private static final String MEASURE_POPULATION = "http://terminology.hl7.org/CodeSystem/measure-population";
-    private static final String INITIAL_POPULATION = "initial-population";
-
     private final IGenericClient storeClient;
+
+    private String taskId;
 
     public EvaluateCqlMeasure(IGenericClient storeClient, ProcessPluginApi api) {
         super(api);
@@ -53,20 +57,39 @@ public class EvaluateCqlMeasure extends AbstractServiceDelegate implements Initi
 
     @Override
     protected void doExecute(DelegateExecution execution, Variables variables) {
-        var measureId = variables.getString(VARIABLE_MEASURE_ID);
+        var measureId = new IdType(variables.getString(VARIABLE_MEASURE_ID));
+        taskId = api.getTaskHelper().getLocalVersionlessAbsoluteUrl(variables.getStartTask());
 
+        logger.debug("Start evaluating Measure '{}' [task: {}]", measureId.getValue(), taskId);
+        var start = System.currentTimeMillis();
         var response = executeEvaluateMeasure(measureId);
+        var duration = System.currentTimeMillis() - start;
         var report = response.filter(Parameters::hasParameter)
                 .map(Parameters::getParameterFirstRep)
                 .filter(ParametersParameterComponent::hasResource)
                 .map(ParametersParameterComponent::getResource)
                 .flatMap(this::toMeasureReport);
         if (report.isEmpty()) {
-            logger.error("Failed to evaluate measure {}", measureId);
+            logger.error("Failed to evaluate measure {} [task: {}]", measureId, taskId);
             throw new RuntimeException("Failed to extract MeasureReport from response");
+        } else {
+            logger.debug("Finished evaluating Measure '{}' {} [task: {}]", measureId.getValue(),
+                    getFormattedExecutionTime(report.get(), duration), taskId);
+            validateMeasureReport(report.get());
+            variables.setResource(VARIABLE_MEASURE_REPORT, report.get());
         }
-        validateMeasureReport(report.get());
-        variables.setResource(VARIABLE_MEASURE_REPORT, report.get());
+    }
+
+    private String getFormattedExecutionTime(MeasureReport report, long duration) {
+        var executionTimeMessage = new StringBuilder();
+        var cqlDurationExt = report.getExtensionByUrl(BLAZE_EVAL_DURATION_URL);
+
+        if (cqlDurationExt != null && cqlDurationExt.getValue() instanceof Quantity) {
+            var cqlDuration = (Quantity) cqlDurationExt.getValue();
+            executionTimeMessage.append(
+                    "(blaze evaluation duration: %s%s) ".formatted(cqlDuration.getValue(), cqlDuration.getUnit()));
+        }
+        return executionTimeMessage.append("(total execution time: %.3fs)".formatted(duration / 1000.0d)).toString();
     }
 
     private Optional<MeasureReport> toMeasureReport(Resource r) {
@@ -81,21 +104,24 @@ public class EvaluateCqlMeasure extends AbstractServiceDelegate implements Initi
                     .filter(MeasureReport.class::isInstance)
                     .map(MeasureReport.class::cast);
             if (report.isEmpty()) {
-                logger.error("Failed to extract MeasureReport from Bundle");
+                logger.error("Failed to extract MeasureReport from Bundle [task: {}]", taskId);
             }
             return report;
         } else if (r instanceof OperationOutcome) {
-            logger.error("Operation failed: {}", ((OperationOutcome) r).getIssueFirstRep().getDiagnostics());
+            logger.error("Operation failed: {} [task: {}]", ((OperationOutcome) r).getIssueFirstRep().getDiagnostics(),
+                    taskId);
             return Optional.empty();
         } else {
-            logger.error("Response contains unexpected resource type: {}", r.getClass().getSimpleName());
+            logger.error("Response contains unexpected resource type: {} [task: {}]", r.getClass().getSimpleName(),
+                    taskId);
             return Optional.empty();
         }
     }
 
-    private Optional<Parameters> executeEvaluateMeasure(String measureId) {
-        logger.debug("Evaluate measure {}", measureId);
-        return Optional.ofNullable(storeClient.operation().onInstance("Measure/" + measureId).named("evaluate-measure")
+    private Optional<Parameters> executeEvaluateMeasure(IdType measureId) {
+        return Optional.ofNullable(storeClient.operation()
+                .onInstance("Measure/" + measureId.getIdPart())
+                .named("evaluate-measure")
                 .withParameter(Parameters.class, "periodStart", new DateType(MEASURE_REPORT_PERIOD_START))
                 .andParameter("periodEnd", new DateType(MEASURE_REPORT_PERIOD_END))
                 .andParameter("reportType", new StringType(MEASURE_REPORT_TYPE_POPULATION))

--- a/mii-process-feasibility/src/main/java/de/medizininformatik_initiative/process/feasibility/service/LogReceiveTimeout.java
+++ b/mii-process-feasibility/src/main/java/de/medizininformatik_initiative/process/feasibility/service/LogReceiveTimeout.java
@@ -19,9 +19,11 @@ public class LogReceiveTimeout extends AbstractServiceDelegate {
     @Override
     protected void doExecute(DelegateExecution execution, Variables variables) throws BpmnError, Exception {
         var target = variables.getTarget();
-        logger.warn("Timeout while waiting for result from {} (endpoint url: {}).",
+        var task = variables.getStartTask();
+        logger.warn("Timeout while waiting for result from {} (endpoint url: {}) [task: {}]",
                 target.getOrganizationIdentifierValue(),
-                target.getEndpointUrl());
+                target.getEndpointUrl(),
+                api.getTaskHelper().getLocalVersionlessAbsoluteUrl(task));
     }
 
 }

--- a/mii-process-feasibility/src/main/java/de/medizininformatik_initiative/process/feasibility/service/SelectRequestTargets.java
+++ b/mii-process-feasibility/src/main/java/de/medizininformatik_initiative/process/feasibility/service/SelectRequestTargets.java
@@ -72,7 +72,8 @@ public class SelectRequestTargets extends AbstractServiceDelegate {
         if (measureRef.isPresent()) {
             return measureRef.get().getReference();
         } else {
-            logger.error("Task {} is missing the measure reference.", task.getId());
+            logger.error("Task is missing the measure reference [task: {}]",
+                    api.getTaskHelper().getLocalVersionlessAbsoluteUrl(task));
             throw new RuntimeException("Missing measure reference.");
         }
     }

--- a/mii-process-feasibility/src/main/java/de/medizininformatik_initiative/process/feasibility/service/StoreLiveResult.java
+++ b/mii-process-feasibility/src/main/java/de/medizininformatik_initiative/process/feasibility/service/StoreLiveResult.java
@@ -45,7 +45,7 @@ public class StoreLiveResult extends AbstractServiceDelegate implements Initiali
 
         var storedMeasureReport = storeMeasureReport(measureReport);
         addMeasureReportReferenceToTaskOutput(task, storedMeasureReport.getIdElement());
-        logger.info("Added measure report {} to {}", storedMeasureReport.getId(), task.getId());
+        logger.info("Added measure report {} [task: {}]", storedMeasureReport.getId(), task.getId());
     }
 
     private void addReadAccessTag(MeasureReport measureReport) {

--- a/mii-process-feasibility/src/main/java/de/medizininformatik_initiative/process/feasibility/service/StoreMeasureReport.java
+++ b/mii-process-feasibility/src/main/java/de/medizininformatik_initiative/process/feasibility/service/StoreMeasureReport.java
@@ -40,7 +40,9 @@ public class StoreMeasureReport extends AbstractServiceDelegate implements Initi
         stripEvaluatedResources(measureReport);
 
         var measureReportId = storeMeasureReport(measureReport);
-        logger.debug("Stored MeasureReport {}", measureReportId);
+        logger.debug("Stored MeasureReport resource: {} [task: {}]",
+                api.getFhirContext().newJsonParser().encodeResourceToString(measureReport),
+                api.getTaskHelper().getLocalVersionlessAbsoluteUrl(task));
 
         addMeasureReportReferenceToTaskOutputs(task, measureReportId.getValue());
         variables.updateTask(task);
@@ -66,7 +68,8 @@ public class StoreMeasureReport extends AbstractServiceDelegate implements Initi
         if (measureRef.isPresent()) {
             measureReport.setMeasure(measureRef.get().getReference());
         } else {
-            logger.error("Task {} is missing the measure reference.", task.getId());
+            logger.error("Task is missing the measure reference [task: {}]",
+                    api.getTaskHelper().getLocalVersionlessAbsoluteUrl(task));
             throw new RuntimeException("Missing measure reference.");
         }
     }

--- a/mii-process-feasibility/src/main/java/de/medizininformatik_initiative/process/feasibility/variables/ConstantsFeasibility.java
+++ b/mii-process-feasibility/src/main/java/de/medizininformatik_initiative/process/feasibility/variables/ConstantsFeasibility.java
@@ -36,4 +36,6 @@ public interface ConstantsFeasibility {
 
     String HEADER_PREFER = "Prefer";
     String HEADER_PREFER_RESPOND_ASYNC = "respond-async";
+    public String MEASURE_POPULATION = "http://terminology.hl7.org/CodeSystem/measure-population";
+    public String INITIAL_POPULATION = "initial-population";
 }

--- a/mii-process-feasibility/src/test/java/de/medizininformatik_initiative/process/feasibility/client/flare/FlareWebserviceClientImplTest.java
+++ b/mii-process-feasibility/src/test/java/de/medizininformatik_initiative/process/feasibility/client/flare/FlareWebserviceClientImplTest.java
@@ -153,12 +153,13 @@ public class FlareWebserviceClientImplTest {
     @Test
     void sendErrorGetsRethrownWithAdditionalInformation() throws Exception {
         var structuredQuery = "foo".getBytes();
-        var error = new IOException("error-151930");
+        var errorMessage = "error-151930";
+        var error = new IOException(errorMessage);
         when(httpClient.execute(any(HttpPost.class), any(BasicResponseHandler.class))).thenThrow(error);
 
         assertThatThrownBy(() -> flareWebserviceClient.requestFeasibility(structuredQuery))
-                .hasMessage("Error sending %s request to flare webservice url '%s'.", POST,
-                        flareBaseUrl.resolve("/query/execute"))
+                .hasMessage("Error sending %s request to flare webservice url '%s': %s", POST,
+                        flareBaseUrl.resolve("/query/execute"), errorMessage)
                 .hasCause(error);
     }
 }

--- a/mii-process-feasibility/src/test/java/de/medizininformatik_initiative/process/feasibility/service/EvaluateCqlMeasureTest.java
+++ b/mii-process-feasibility/src/test/java/de/medizininformatik_initiative/process/feasibility/service/EvaluateCqlMeasureTest.java
@@ -2,6 +2,8 @@ package de.medizininformatik_initiative.process.feasibility.service;
 
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.gclient.IOperationUntypedWithInput;
+import dev.dsf.bpe.v1.ProcessPluginApi;
+import dev.dsf.bpe.v1.service.TaskHelper;
 import dev.dsf.bpe.v1.variables.Variables;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.hl7.fhir.r4.model.Bundle;
@@ -52,6 +54,8 @@ public class EvaluateCqlMeasureTest {
     @Mock private DelegateExecution execution;
     @Mock private Variables variables;
     @Mock private IOperationUntypedWithInput<Parameters> operation;
+    @Mock private ProcessPluginApi api;
+    @Mock private TaskHelper taskHelper;
 
     @InjectMocks private EvaluateCqlMeasure service;
 
@@ -75,6 +79,7 @@ public class EvaluateCqlMeasureTest {
                         .thenReturn(operation);
         when(operation.withAdditionalHeader(eq(HEADER_PREFER), eq(HEADER_PREFER_RESPOND_ASYNC))).thenReturn(operation);
         when(variables.getString(VARIABLE_MEASURE_ID)).thenReturn(MEASURE_ID);
+        when(api.getTaskHelper()).thenReturn(taskHelper);
     }
 
     @Test

--- a/mii-process-feasibility/src/test/java/de/medizininformatik_initiative/process/feasibility/service/StoreFeasibilityResourcesTest.java
+++ b/mii-process-feasibility/src/test/java/de/medizininformatik_initiative/process/feasibility/service/StoreFeasibilityResourcesTest.java
@@ -1,18 +1,27 @@
 package de.medizininformatik_initiative.process.feasibility.service;
 
 import ca.uhn.fhir.rest.client.api.IGenericClient;
+import dev.dsf.bpe.v1.ProcessPluginApi;
+import dev.dsf.bpe.v1.service.TaskHelper;
 import dev.dsf.bpe.v1.variables.Variables;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Library;
 import org.hl7.fhir.r4.model.Measure;
+import org.hl7.fhir.r4.model.Task;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.*;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static de.medizininformatik_initiative.process.feasibility.Assertions.assertThat;
-import static de.medizininformatik_initiative.process.feasibility.variables.ConstantsFeasibility.*;
+import static de.medizininformatik_initiative.process.feasibility.variables.ConstantsFeasibility.VARIABLE_LIBRARY;
+import static de.medizininformatik_initiative.process.feasibility.variables.ConstantsFeasibility.VARIABLE_MEASURE;
+import static de.medizininformatik_initiative.process.feasibility.variables.ConstantsFeasibility.VARIABLE_MEASURE_ID;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hl7.fhir.r4.model.Bundle.HTTPVerb.POST;
@@ -22,23 +31,22 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 public class StoreFeasibilityResourcesTest {
 
+    private static final String TASK_URL = "http://foo.bar/Task/123";
     public static final String LIBRARY_ID = "library-id-173603";
     public static final String MEASURE_ID = "measure-id-173603";
 
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private IGenericClient storeClient;
 
-    @Mock
-    private FeasibilityResourceCleaner cleaner;
+    @Mock private FeasibilityResourceCleaner cleaner;
+    @Mock private DelegateExecution execution;
+    @Mock private Variables variables;
+    @Mock private ProcessPluginApi api;
+    @Mock private TaskHelper taskHelper;
 
     @Captor
     private ArgumentCaptor<Bundle> transactionBundleCaptor;
 
-    @Mock
-    private DelegateExecution execution;
-
-    @Mock
-    private Variables variables;
 
     @InjectMocks
     private StoreFeasibilityResources service;
@@ -86,11 +94,16 @@ public class StoreFeasibilityResourcesTest {
     public void testDoExecute() {
         var inputMeasure = inputMeasure();
         var inputLibrary = inputLibrary();
+        var task = new Task();
         var transactionResponse = new Bundle();
-        transactionResponse.addEntry().getResponse().setLocation("Measure/" + MEASURE_ID);
+        var measureLocation = "http://foo.bar/Measure/" + MEASURE_ID;
+        transactionResponse.addEntry().getResponse().setLocation(measureLocation);
         inputLibrary.getContentFirstRep().setContentType("text/cql");
         when(variables.getResource(VARIABLE_MEASURE)).thenReturn(inputMeasure);
         when(variables.getResource(VARIABLE_LIBRARY)).thenReturn(inputLibrary);
+        when(variables.getStartTask()).thenReturn(task);
+        when(api.getTaskHelper()).thenReturn(taskHelper);
+        when(taskHelper.getLocalVersionlessAbsoluteUrl(task)).thenReturn("http://foo.bar/Task/123");
         when(storeClient.transaction().withBundle(transactionBundleCaptor.capture()).execute()).thenReturn(transactionResponse);
 
         service.doExecute(execution, variables);
@@ -109,6 +122,6 @@ public class StoreFeasibilityResourcesTest {
         assertThat(transactionBundleCaptor.getValue().getEntry().get(1).getRequest())
                 .hasMethod(POST)
                 .hasUrl("Library");
-        verify(variables).setString(VARIABLE_MEASURE_ID, MEASURE_ID);
+        verify(variables).setString(VARIABLE_MEASURE_ID, measureLocation);
     }
 }

--- a/mii-process-feasibility/src/test/java/de/medizininformatik_initiative/process/feasibility/service/StoreMeasureReportTest.java
+++ b/mii-process-feasibility/src/test/java/de/medizininformatik_initiative/process/feasibility/service/StoreMeasureReportTest.java
@@ -1,5 +1,6 @@
 package de.medizininformatik_initiative.process.feasibility.service;
 
+import ca.uhn.fhir.context.FhirContext;
 import dev.dsf.bpe.v1.ProcessPluginApi;
 import dev.dsf.bpe.v1.service.FhirWebserviceClientProvider;
 import dev.dsf.bpe.v1.service.TaskHelper;
@@ -80,6 +81,7 @@ public class StoreMeasureReportTest
         when(variables.getStartTask()).thenReturn(task);
         when(api.getReadAccessHelper()).thenReturn(readAccessHelper);
         when(api.getFhirWebserviceClientProvider()).thenReturn(clientProvider);
+        when(api.getFhirContext()).thenReturn(FhirContext.forR4());
         when(clientProvider.getLocalWebserviceClient()).thenReturn(localWebserviceClient);
         when(localWebserviceClient.withMinimalReturn()).thenReturn(returnMinimal);
         when(returnMinimal.create(measureReportCaptor.capture())).thenReturn(measureReportId);

--- a/mii-process-feasibility/src/test/java/de/medizininformatik_initiative/process/feasibility/service/StoreMeasureReportTest.java
+++ b/mii-process-feasibility/src/test/java/de/medizininformatik_initiative/process/feasibility/service/StoreMeasureReportTest.java
@@ -1,6 +1,5 @@
 package de.medizininformatik_initiative.process.feasibility.service;
 
-import ca.uhn.fhir.context.FhirContext;
 import dev.dsf.bpe.v1.ProcessPluginApi;
 import dev.dsf.bpe.v1.service.FhirWebserviceClientProvider;
 import dev.dsf.bpe.v1.service.TaskHelper;
@@ -81,7 +80,6 @@ public class StoreMeasureReportTest
         when(variables.getStartTask()).thenReturn(task);
         when(api.getReadAccessHelper()).thenReturn(readAccessHelper);
         when(api.getFhirWebserviceClientProvider()).thenReturn(clientProvider);
-        when(api.getFhirContext()).thenReturn(FhirContext.forR4());
         when(clientProvider.getLocalWebserviceClient()).thenReturn(localWebserviceClient);
         when(localWebserviceClient.withMinimalReturn()).thenReturn(returnMinimal);
         when(returnMinimal.create(measureReportCaptor.capture())).thenReturn(measureReportId);


### PR DESCRIPTION
Unify debug logs and add execution time and (obfuscated) result count.

Add instructions to readme how to retrieve Structured and CQL queries.