### PR TITLE
Remove Setting Measure Reference in Measure Report Twice

### DIFF
--- a/mii-process-feasibility/src/main/java/de/medizininformatik_initiative/process/feasibility/service/EvaluateStructuredQueryMeasure.java
+++ b/mii-process-feasibility/src/main/java/de/medizininformatik_initiative/process/feasibility/service/EvaluateStructuredQueryMeasure.java
@@ -8,7 +8,6 @@ import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Library;
-import org.hl7.fhir.r4.model.Measure;
 import org.hl7.fhir.r4.model.MeasureReport;
 import org.hl7.fhir.r4.model.MeasureReport.MeasureReportGroupComponent;
 import org.hl7.fhir.r4.model.MeasureReport.MeasureReportGroupPopulationComponent;
@@ -25,7 +24,6 @@ import static de.medizininformatik_initiative.process.feasibility.variables.Cons
 import static de.medizininformatik_initiative.process.feasibility.variables.ConstantsFeasibility.MEASURE_REPORT_PERIOD_END;
 import static de.medizininformatik_initiative.process.feasibility.variables.ConstantsFeasibility.MEASURE_REPORT_PERIOD_START;
 import static de.medizininformatik_initiative.process.feasibility.variables.ConstantsFeasibility.VARIABLE_LIBRARY;
-import static de.medizininformatik_initiative.process.feasibility.variables.ConstantsFeasibility.VARIABLE_MEASURE;
 import static de.medizininformatik_initiative.process.feasibility.variables.ConstantsFeasibility.VARIABLE_MEASURE_REPORT;
 import static org.hl7.fhir.r4.model.MeasureReport.MeasureReportStatus.COMPLETE;
 import static org.hl7.fhir.r4.model.MeasureReport.MeasureReportType.SUMMARY;
@@ -51,11 +49,9 @@ public class EvaluateStructuredQueryMeasure extends AbstractServiceDelegate impl
     protected void doExecute(DelegateExecution execution, Variables variables)
             throws IOException, InterruptedException {
         var library = (Library) variables.getResource(VARIABLE_LIBRARY);
-        var measure = (Measure) variables.getResource(VARIABLE_MEASURE);
-
         var structuredQuery = getStructuredQuery(library);
         var feasibility = getFeasibility(structuredQuery);
-        var measureReport = buildMeasureReport(measure.getUrl(), feasibility);
+        var measureReport = buildMeasureReport(feasibility);
 
         variables.setResource(VARIABLE_MEASURE_REPORT, measureReport);
     }
@@ -72,12 +68,11 @@ public class EvaluateStructuredQueryMeasure extends AbstractServiceDelegate impl
         return flareClient.requestFeasibility(structuredQuery);
     }
 
-    private MeasureReport buildMeasureReport(String measureRef, int feasibility) {
+    private MeasureReport buildMeasureReport(int feasibility) {
         var measureReport = new MeasureReport()
                 .setStatus(COMPLETE)
                 .setType(SUMMARY)
                 .setDate(new Date())
-                .setMeasure(measureRef)
                 .setPeriod(new Period()
                         .setStart(MEASURE_REPORT_PERIOD_START)
                         .setEnd(MEASURE_REPORT_PERIOD_END));

--- a/mii-process-feasibility/src/main/java/de/medizininformatik_initiative/process/feasibility/service/ObfuscateEvaluationResult.java
+++ b/mii-process-feasibility/src/main/java/de/medizininformatik_initiative/process/feasibility/service/ObfuscateEvaluationResult.java
@@ -57,7 +57,6 @@ public class ObfuscateEvaluationResult extends AbstractServiceDelegate
         var obfuscatedMeasureReport = new MeasureReport()
                 .setStatus(COMPLETE)
                 .setType(SUMMARY)
-                .setMeasure(measureReport.getMeasure())
                 .setPeriod(new Period()
                         .setStart(MEASURE_REPORT_PERIOD_START)
                         .setEnd(MEASURE_REPORT_PERIOD_END));

--- a/mii-process-feasibility/src/main/java/de/medizininformatik_initiative/process/feasibility/service/SelectRequestTargets.java
+++ b/mii-process-feasibility/src/main/java/de/medizininformatik_initiative/process/feasibility/service/SelectRequestTargets.java
@@ -2,7 +2,6 @@ package de.medizininformatik_initiative.process.feasibility.service;
 
 import dev.dsf.bpe.v1.ProcessPluginApi;
 import dev.dsf.bpe.v1.activity.AbstractServiceDelegate;
-import dev.dsf.bpe.v1.variables.Target;
 import dev.dsf.bpe.v1.variables.Variables;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.hl7.fhir.r4.model.Coding;
@@ -15,7 +14,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URI;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -43,7 +41,7 @@ public class SelectRequestTargets extends AbstractServiceDelegate {
         var memberOrganizationRole = new Coding()
                 .setSystem("http://dsf.dev/fhir/CodeSystem/organization-role")
                 .setCode("DIC");
-        List<Target> targets = organizationProvider
+        var targets = organizationProvider
                 .getOrganizations(parentIdentifier, memberOrganizationRole)
                 .stream()
                 .filter(Organization::hasEndpoint)

--- a/mii-process-feasibility/src/test/java/de/medizininformatik_initiative/process/feasibility/service/EvaluateStructuredQueryMeasureTest.java
+++ b/mii-process-feasibility/src/test/java/de/medizininformatik_initiative/process/feasibility/service/EvaluateStructuredQueryMeasureTest.java
@@ -6,7 +6,6 @@ import dev.dsf.bpe.v1.variables.Variables;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.hl7.fhir.r4.model.Attachment;
 import org.hl7.fhir.r4.model.Library;
-import org.hl7.fhir.r4.model.Measure;
 import org.hl7.fhir.r4.model.MeasureReport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,7 +19,6 @@ import java.io.IOException;
 import java.util.List;
 
 import static de.medizininformatik_initiative.process.feasibility.variables.ConstantsFeasibility.VARIABLE_LIBRARY;
-import static de.medizininformatik_initiative.process.feasibility.variables.ConstantsFeasibility.VARIABLE_MEASURE;
 import static de.medizininformatik_initiative.process.feasibility.variables.ConstantsFeasibility.VARIABLE_MEASURE_REPORT;
 import static org.hl7.fhir.r4.model.MeasureReport.MeasureReportStatus.COMPLETE;
 import static org.hl7.fhir.r4.model.MeasureReport.MeasureReportType.SUMMARY;
@@ -44,10 +42,8 @@ public class EvaluateStructuredQueryMeasureTest {
 
     @Test
     public void testDoExecute_FailsIfStructuredQueryContentIsMissing() {
-        var measure = new Measure();
         var library = new Library();
 
-        when(variables.getResource(VARIABLE_MEASURE)).thenReturn(measure);
         when(variables.getResource(VARIABLE_LIBRARY)).thenReturn(library);
 
         assertThrows(IllegalStateException.class, () -> service.doExecute(execution, variables));
@@ -56,15 +52,11 @@ public class EvaluateStructuredQueryMeasureTest {
     @Test
     public void testDoExecute_FailsIfFeasibilityCannotBeRequested() throws IOException, InterruptedException {
         var structuredQuery = "foo".getBytes();
-
-        var measure = new Measure();
-        measure.setUrl("https://my-zars/Measure/a9d981ed-58dd-4213-9abf-cb86ab757162");
         var library = new Library();
         library.setContent(List.of(new Attachment()
                 .setContentType("application/json")
                 .setData(structuredQuery)));
 
-        when(variables.getResource(VARIABLE_MEASURE)).thenReturn(measure);
         when(variables.getResource(VARIABLE_LIBRARY)).thenReturn(library);
         when(flareWebserviceClient.requestFeasibility(structuredQuery)).thenThrow(IOException.class);
 
@@ -74,15 +66,11 @@ public class EvaluateStructuredQueryMeasureTest {
     @Test
     public void testDoExecute_FailsIfLibraryDoesNotContainStructuredQuery() {
         var structuredQuery = "foo".getBytes();
-
-        var measure = new Measure();
-        measure.setUrl("https://my-zars/Measure/a9d981ed-58dd-4213-9abf-cb86ab757162");
         var library = new Library();
         library.setContent(List.of(new Attachment()
                 .setContentType("text/plain")
                 .setData(structuredQuery)));
 
-        when(variables.getResource(VARIABLE_MEASURE)).thenReturn(measure);
         when(variables.getResource(VARIABLE_LIBRARY)).thenReturn(library);
 
         assertThrows(IllegalStateException.class, () -> service.doExecute(execution, variables));
@@ -91,17 +79,12 @@ public class EvaluateStructuredQueryMeasureTest {
     @Test
     public void testDoExecute() throws IOException, InterruptedException {
         var structuredQuery = "foo".getBytes();
-        var measureRef = "https://my-zars/Measure/a9d981ed-58dd-4213-9abf-cb86ab757162";
-
-        var measure = new Measure();
-        measure.setUrl(measureRef);
         var library = new Library();
         library.setContent(List.of(new Attachment()
                 .setContentType("application/json")
                 .setData(structuredQuery)));
         var feasibility = 10;
 
-        when(variables.getResource(VARIABLE_MEASURE)).thenReturn(measure);
         when(variables.getResource(VARIABLE_LIBRARY)).thenReturn(library);
         when(flareWebserviceClient.requestFeasibility(structuredQuery)).thenReturn(feasibility);
 
@@ -111,7 +94,6 @@ public class EvaluateStructuredQueryMeasureTest {
         var measureReport = measureReportCaptor.getValue();
         assertEquals(COMPLETE, measureReport.getStatus());
         assertEquals(SUMMARY, measureReport.getType());
-        assertEquals(measureRef, measureReport.getMeasure());
         assertEquals(feasibility, measureReport.getGroup().get(0).getPopulation().get(0).getCount());
     }
 }

--- a/mii-process-feasibility/src/test/java/de/medizininformatik_initiative/process/feasibility/service/ObfuscateEvaluationResultTest.java
+++ b/mii-process-feasibility/src/test/java/de/medizininformatik_initiative/process/feasibility/service/ObfuscateEvaluationResultTest.java
@@ -73,11 +73,9 @@ public class ObfuscateEvaluationResultTest {
     public void doExecuteSucceedsSinglePopulationSingleCoding() throws Exception {
         var feasibilityCount = 5;
         var reportDate = new Date();
-        var measureUrl = "http://localhost/fhir/Measure/123456";
         var measureReport = new MeasureReport()
                 .setStatus(COMPLETE)
                 .setType(SUMMARY)
-                .setMeasure(measureUrl)
                 .setDate(reportDate)
                 .setPeriod(new Period()
                         .setStart(new LocalDate(1312, 4, 9).toDate())
@@ -104,7 +102,6 @@ public class ObfuscateEvaluationResultTest {
         var reportPopulation = obfuscatedMeasureReport.getGroupFirstRep().getPopulationFirstRep();
         assertThat(obfuscatedMeasureReport.getStatus()).isEqualTo(COMPLETE);
         assertThat(obfuscatedMeasureReport.getType()).isEqualTo(SUMMARY);
-        assertThat(obfuscatedMeasureReport.getMeasure()).isEqualTo(measureUrl);
         assertThat(obfuscatedMeasureReport.hasDate()).isFalse();
         assertThat(obfuscatedMeasureReport.getPeriod().getStart()).isEqualTo(MEASURE_REPORT_PERIOD_START);
         assertThat(obfuscatedMeasureReport.getPeriod().getEnd()).isEqualTo(MEASURE_REPORT_PERIOD_END);


### PR DESCRIPTION
The `url` property of the Measure resource is not an resource location, as the name would imply, but just an URI which can be independent of any FHIR server the resource is stored in.
Therefor these changes do not alter the `url` property but just clean up some unnecessary code and remove the last usage of the property as reference in the measure report which already gets overridden in a subsequent step.